### PR TITLE
Fixing pass parameter channel with message EVENT_CHANNEL_MEMBERS_UPDATE

### DIFF
--- a/dota2/features/chat.py
+++ b/dota2/features/chat.py
@@ -135,7 +135,7 @@ class ChannelManager(EventEmitter):
             channel._process_members_from_proto(message)
 
             if joined or left:
-                self.emit(self.EVENT_CHANNEL_MEMBERS_UPDATE, joined, left)
+                self.emit(self.EVENT_CHANNEL_MEMBERS_UPDATE, channel, joined, left)
 
     def join_channel(self, channel_name, channel_type=DOTAChatChannelType_t.DOTAChannelType_Custom):
         """Join a chat channel


### PR DESCRIPTION
Documentation says, that we get this parameters (3):

EVENT_CHANNEL_MEMBERS_UPDATE = 'members_update'
    """When users join/leave a channel

    :param channel: channel instance
    :type  channel: :class:`ChatChannel`
    :param joined: list of members who joined
    :type  joined: list
    :param left: list of members who left
    :type  left: list
    """

But in real, only `joined` and `left` passed. 
A little fix, to pass channel too