### PR TITLE
Add a destroy lobby feature.

### DIFF
--- a/dota2/features/lobby.py
+++ b/dota2/features/lobby.py
@@ -400,3 +400,13 @@ class Lobby(object):
             "lobby_id": lobby_id,
             "accept": accept
         })
+
+    def destroy_lobby(self):
+        """
+        Destroy the lobby currently in if host.
+        """
+        if self.verbose_debug:
+            self._LOG.debug("Destroying current lobby.")
+
+        self.send(EDOTAGCMsg.EMsgDestroyLobbyRequest, {})
+


### PR DESCRIPTION
Destroying lobby is useful if you want to totally end a lobby instead of just leaving it. There is a response to this request, but I have chosen to omit it, even if we could listen to the response to return True/False depending on the response.